### PR TITLE
Fix formatting behavior

### DIFF
--- a/AGInputControls.podspec
+++ b/AGInputControls.podspec
@@ -1,14 +1,6 @@
-#
-# Be sure to run `pod lib lint IVCollectionKit.podspec' to ensure this is a
-# valid spec before submitting.
-#
-# Any lines starting with a # are optional, but their use is encouraged
-# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
-#
-
 Pod::Spec.new do |s|
   s.name             = 'AGInputControls'
-  s.version          = '1.1.2'
+  s.version          = '1.1.3'
   s.summary          = 'Commonly used text input controls'
   s.description      = <<-DESC
 TODO: Add long description of the pod here.
@@ -16,7 +8,7 @@ TODO: Add long description of the pod here.
 
   s.homepage         = 'https://github.com/ivedeneev/AGInputControls.git'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
-  s.author           = { 'ivedeneev' => 'i.vedeneev@agima.ru' }
+  s.author           = { 'ivedeneev' => 'getmaxx@hotmail.com' }
   s.source           = { :git => 'https://github.com/ivedeneev/AGInputControls.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '9.0'

--- a/AGInputControls/Source/FormattingTextField+Extension.swift
+++ b/AGInputControls/Source/FormattingTextField+Extension.swift
@@ -10,7 +10,8 @@ import UIKit
 extension FormattingTextField {
     
     internal func setCursorPosition(offset: Int) {
-        guard let newPosition = position(from: beginningOfDocument, in: .right, offset: offset) else {return }
+        let fixedOffset = max(offset, prefix.count)
+        guard let newPosition = position(from: beginningOfDocument, in: .right, offset: fixedOffset) else {return }
         selectedTextRange = textRange(from: newPosition, to: newPosition)
     }
     
@@ -27,16 +28,11 @@ extension FormattingTextField {
     }
     
     internal func sizeOfText(_ text: String) -> CGSize {
+        guard let font else { return .zero }
         return (text as NSString).boundingRect(
             with: UIScreen.main.bounds.size,
             options: [.usesFontLeading, .usesLineFragmentOrigin],
             attributes: [.font : font],
             context: nil).size
-    }
-    
-    internal func assertForExampleMasksAndPrefix() {
-        guard let mask = exampleMask, !mask.isEmpty, let formattingMask = formattingMask, formatter != nil else { return }
-        assert(mask == formattedText(text: mask) && mask.count == formattingMask.count, "Formatting mask and example mask should be in same format. This is your responsibility as a developer\nExampleMask: \(mask)\nFormatting mask: \(formattingMask)")
-        assert(prefix.first(where: { $0.isLetter || $0.isNumber }) == nil || hasConstantPrefix, "You cannot have 'semi constant' prefixes at this point ")
     }
 }

--- a/AGInputControls/Source/FormattingTextField.swift
+++ b/AGInputControls/Source/FormattingTextField.swift
@@ -37,10 +37,14 @@ open class FormattingTextField: UITextField {
         
         set {
             let formatted = formattedText(text: newValue)
-            var pos = currentPosition()
+            let pos = currentPosition()
             super.text = formatted
             notifyDelegate(text: text)
-            setCaretPositionAfterSettingText(currentPosition: pos, rawText: newValue, formattedText: formatted)
+            setCaretPositionAfterSettingText(
+                currentPosition: pos,
+                rawText: newValue,
+                formattedText: formatted
+            )
         }
     }
     
@@ -206,6 +210,40 @@ open class FormattingTextField: UITextField {
         }
     }
     
+    open override func becomeFirstResponder() -> Bool {
+        if text.isEmptyOrTrue && !showsMaskIfEmpty && !_showsMask && formatter != nil {
+            _showsMask = true
+            setNeedsDisplay()
+        }
+        return super.becomeFirstResponder()
+    }
+    
+    open override func resignFirstResponder() -> Bool {
+        if text.isEmptyOrTrue && !showsMaskIfEmpty && _showsMask && formatter != nil {
+            _showsMask = false
+            setNeedsDisplay()
+        }
+        return super.resignFirstResponder()
+    }
+    
+    open override func textRect(forBounds bounds: CGRect) -> CGRect {
+        guard let exampleMask else {
+            return super.editingRect(forBounds: bounds)
+        }
+        let w = sizeOfText(exampleMask).width
+        let originX = (bounds.width - w) / 2
+        return CGRect(x: originX, y: 0, width: w, height: bounds.height)
+    }
+    
+    open override func editingRect(forBounds bounds: CGRect) -> CGRect {
+        guard let exampleMask else {
+            return super.editingRect(forBounds: bounds)
+        }
+        let w = sizeOfText(exampleMask).width
+        let originX = (bounds.width - w) / 2
+        return CGRect(x: originX, y: 0, width: w, height: bounds.height)
+    }
+    
     //MARK: Public methods
     @available(*, deprecated, renamed: "text", message: "Use regular text setter to set formatted text programmatically ")
     open func setFormattedText(_ text: String?) {
@@ -240,7 +278,10 @@ open class FormattingTextField: UITextField {
                 range: .init(location: 0, length: prefix.count)
             )
         }
-        let originX = placeholderRect(forBounds: bounds).origin.x
+        
+        let w = sizeOfText(exampleMask!).width
+        let originX = (bounds.width - w) / 2
+        
         textToDraw.draw(at: CGPoint(x: originX, y: ((bounds.height - font.lineHeight) / 2)))
     }
     
@@ -271,22 +312,6 @@ open class FormattingTextField: UITextField {
                 formattingDelegate?.textField(textField: self, didOccurUnacceptedCharacter: letter)
             }
         }
-    }
-    
-    open override func becomeFirstResponder() -> Bool {
-        if text.isEmptyOrTrue && !showsMaskIfEmpty && !_showsMask && formatter != nil {
-            _showsMask = true
-            setNeedsDisplay()
-        }
-        return super.becomeFirstResponder()
-    }
-    
-    open override func resignFirstResponder() -> Bool {
-        if text.isEmptyOrTrue && !showsMaskIfEmpty && _showsMask && formatter != nil {
-            _showsMask = false
-            setNeedsDisplay()
-        }
-        return super.resignFirstResponder()
     }
     
     //MARK: Private & internal

--- a/AGInputControls/Source/FormattingTextField.swift
+++ b/AGInputControls/Source/FormattingTextField.swift
@@ -37,9 +37,10 @@ open class FormattingTextField: UITextField {
         
         set {
             let formatted = formattedText(text: newValue)
+            var pos = currentPosition()
             super.text = formatted
             notifyDelegate(text: text)
-            setCaretPositionAfterSettingText(rawText: newValue, formattedText: formatted)
+            setCaretPositionAfterSettingText(currentPosition: pos, rawText: newValue, formattedText: formatted)
         }
     }
     
@@ -295,8 +296,8 @@ open class FormattingTextField: UITextField {
         assert(prefix.first(where: { $0.isLetter || $0.isNumber }) == nil || hasConstantPrefix, "You cannot have 'semi constant' prefixes at this point ")
     }
     
-    func setCaretPositionAfterSettingText(rawText:String?, formattedText: String?) {
-        var pos = currentPosition()
+    func setCaretPositionAfterSettingText(currentPosition: Int, rawText:String?, formattedText: String?) {
+        var pos = currentPosition
         let textCount = rawText?.count ?? 0
         guard let last = formattedText?.prefix(pos).last else { return }
     
@@ -306,12 +307,12 @@ open class FormattingTextField: UITextField {
         if pos < textCount {
             setCursorPosition(offset: pos)
         } else if let count = formattedText?.count {
-//            let delta = count - textCount
-//            if abs(delta) > 2 {
-//                DispatchQueue.main.async { // async because it may interfere with setting cursor position initiated by system
-//                    self.setCursorPosition(offset: pos + delta)
-//                }
-//            }
+            let delta = count - textCount
+            if abs(delta) > 2 {
+                DispatchQueue.main.async { // async because it may interfere with setting cursor position initiated by system
+                    self.setCursorPosition(offset: pos + delta)
+                }
+            }
         }
     }
 }

--- a/AGInputControls/Source/FormattingTextField.swift
+++ b/AGInputControls/Source/FormattingTextField.swift
@@ -75,9 +75,10 @@ open class FormattingTextField: UITextField {
     
     //MARK: Overriden properties
     open override var intrinsicContentSize: CGSize {
-        guard let exampleMask = formattingMask ??
-              formattingMask?.replacingOccurrences(of: "#", with: "0"),
-              !exampleMask.isEmpty // in case of monospaced digit fonts calculatiing width againts only digit text produces more accurate results
+        guard let exampleMask = formattingMask?
+            .replacingOccurrences(of: "#", with: "0")
+            .replacingOccurrences(of: "_", with: "0"),
+            !exampleMask.isEmpty // in case of monospaced digit fonts calculatiing width againts only digit text produces more accurate results
         else {
             return super.intrinsicContentSize
         }
@@ -87,8 +88,9 @@ open class FormattingTextField: UITextField {
         let width = sizeOfText(exampleMask).width
         
         let caretWidth: CGFloat = caretRect(for: endOfDocument).width
+        let padding: CGFloat = 0
         
-        return CGSize(width: width + caretWidth, height: height)
+        return CGSize(width: width + caretWidth + padding * 2, height: height)
     }
     
     open override var font: UIFont? {
@@ -227,21 +229,24 @@ open class FormattingTextField: UITextField {
     }
     
     open override func textRect(forBounds bounds: CGRect) -> CGRect {
-        guard let exampleMask else {
+        guard let exampleMask = exampleMask?.replacingOccurrences(of: "_", with: "0") else {
             return super.editingRect(forBounds: bounds)
         }
+        
         let w = sizeOfText(exampleMask).width
         let originX = (bounds.width - w) / 2
-        return CGRect(x: originX, y: 0, width: w, height: bounds.height)
+        return CGRect(x: originX, y: 0, width: w + 14, height: bounds.height)
     }
     
     open override func editingRect(forBounds bounds: CGRect) -> CGRect {
-        guard let exampleMask else {
+        guard let exampleMask = exampleMask?.replacingOccurrences(of: "_", with: "0") else {
             return super.editingRect(forBounds: bounds)
         }
+        
+        let caretWidth: CGFloat = caretRect(for: endOfDocument).width
         let w = sizeOfText(exampleMask).width
         let originX = (bounds.width - w) / 2
-        return CGRect(x: originX, y: 0, width: w, height: bounds.height)
+        return CGRect(x: originX, y: 0, width: w + caretWidth, height: bounds.height)
     }
     
     //MARK: Public methods
@@ -279,7 +284,7 @@ open class FormattingTextField: UITextField {
             )
         }
         
-        let w = sizeOfText(exampleMask!).width
+        let w = sizeOfText(mask.replacingOccurrences(of: "_", with: "0")).width
         let originX = (bounds.width - w) / 2
         
         textToDraw.draw(at: CGPoint(x: originX, y: ((bounds.height - font.lineHeight) / 2)))

--- a/AGInputControls/Source/PhoneTextField.swift
+++ b/AGInputControls/Source/PhoneTextField.swift
@@ -36,4 +36,14 @@ open class PhoneTextField: FormattingTextField {
         }
         keyboardType = .phonePad
     }
+    
+    override func assertForExampleMasksAndPrefix() {
+        guard let mask = exampleMask, !mask.isEmpty, let formattingMask = formattingMask, formatter != nil else { return }
+        
+        // It is common for phone fields to have _ 
+        let fixedMask = mask.replacingOccurrences(of: "_", with: "0")
+        
+        assert(fixedMask == formattedText(text: fixedMask) && fixedMask.count == formattingMask.count, "Formatting mask and example mask should be in same format. This is your responsibility as a developer\nExampleMask: \(mask)\nFormatting mask: \(formattingMask)")
+        assert(prefix.first(where: { $0.isLetter || $0.isNumber }) == nil || hasConstantPrefix, "You cannot have 'semi constant' prefixes at this point ")
+    }
 }

--- a/AGInputControls/Source/PhoneTextField.swift
+++ b/AGInputControls/Source/PhoneTextField.swift
@@ -19,6 +19,22 @@ open class PhoneTextField: FormattingTextField {
             formatter = PhoneNumberFormatter(mask: formattingMask)
         }
     }
+    
+    open override var textAlignment: NSTextAlignment {
+        get {
+            super.textAlignment
+        }
+        
+        set {
+            /// `.center` just doesnt make sense from UX perspective if mask is enabled. We would expect to gradually replace placeholder with text which doesnt work with center alignment
+            guard formattingMask != nil && newValue == .center else {
+                super.textAlignment = newValue
+                return
+            }
+            
+            super.textAlignment = .left //TODO: check RTL languages
+        }
+    }
 
     override public init(frame: CGRect) {
         super.init(frame: frame)

--- a/AGInputControls/Source/String+Extension.swift
+++ b/AGInputControls/Source/String+Extension.swift
@@ -35,6 +35,10 @@ extension String {
     func alphanumeric() -> String {
         components(separatedBy: CharacterSet.letters.inverted).joined()
     }
+    
+    func replacingUnderscoresWithZeros() -> String {
+        replacingOccurrences(of: "_", with: "0")
+    }
 }
 
 internal extension Optional where Wrapped == String {

--- a/AGInputControlsTests/AcceptedLettersTests.swift
+++ b/AGInputControlsTests/AcceptedLettersTests.swift
@@ -27,21 +27,21 @@ class AcceptedLettersTests: XCTestCase {
     }
     
     func testUnacceptedLettersDelegateMethodCalled() {
-        textField.setFormattedText("gз")
+        textField.text = "gз"
         XCTAssertEqual(delegate.unacceptedCharCalled, 1)
     }
     
     
     func testNotifyingDelegateWithEmptyMaskAndNonEmptyString() {
         textField.formatter = EmptyMaskFormatter()
-        textField.setFormattedText("gfhdskjfhdskjfhds")
+        textField.text = "gfhdskjfhdskjfhds"
         XCTAssertEqual(delegate.isValidCalled, 1)
         XCTAssertEqual(delegate.isValid, true)
     }
     
     func testNotifyingDelegateWithEmptyMaskAndEmptyString() {
         textField.formatter = EmptyMaskFormatter()
-        textField.setFormattedText("")
+        textField.text = ""
         XCTAssertEqual(delegate.isValidCalled, 1)
         XCTAssertEqual(delegate.isValid, false)
     }

--- a/AGInputControlsTests/PhoneNumberFieldTests.swift
+++ b/AGInputControlsTests/PhoneNumberFieldTests.swift
@@ -34,7 +34,7 @@ class PhoneNumberFieldTests: XCTestCase {
         XCTAssertEqual(textField.prefix, "+31")
         
         textField.formattingMask = "+## ### ### ## ###"
-        textField.setFormattedText("+31 970 102 81 448")
+        textField.text = "+31 970 102 81 448"
         XCTAssertEqual(textField.text, "+31 970 102 81 448")
         
 //    +442037691880
@@ -42,7 +42,7 @@ class PhoneNumberFieldTests: XCTestCase {
     
     func testReplacing8withPlus7ForRussianNumbersIfConstantMaskWasSet() {
         textField.formattingMask = "+7 ### ###-##-##"
-        textField.setFormattedText("89153051653")
+        textField.text = "89153051653"
         XCTAssertEqual(textField.text, "+7 915 305-16-53")
     }
     
@@ -54,7 +54,7 @@ class PhoneNumberFieldTests: XCTestCase {
     
     func testRussianPhones() {
         textField.formattingMask = "+7 ### ###-##-##"
-        textField.setFormattedText("79250441416")
+        textField.text = "79250441416"
         XCTAssertEqual(textField.text, "+7 925 044-14-16")
     }
 

--- a/Examples/Base.lproj/Main.storyboard
+++ b/Examples/Base.lproj/Main.storyboard
@@ -81,8 +81,34 @@
                                                     <constraint firstAttribute="height" constant="120" id="uSC-mw-0on"/>
                                                 </constraints>
                                             </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8XK-Ga-C4T" userLabel="phone_bg">
+                                                <rect key="frame" x="0.0" y="256" width="414" height="120"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PhoneTextField" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gfc-WF-3FH">
+                                                        <rect key="frame" x="0.0" y="8" width="414" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <color key="textColor" systemColor="systemGrayColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="R5f-hd-cj8" customClass="PhoneTextField" customModule="AGInputControls">
+                                                        <rect key="frame" x="191" y="36.5" width="32" height="34"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                </subviews>
+                                                <viewLayoutGuide key="safeArea" id="LrX-PM-Rpx"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="120" id="5R6-Bb-fNz"/>
+                                                    <constraint firstItem="R5f-hd-cj8" firstAttribute="centerX" secondItem="Gfc-WF-3FH" secondAttribute="centerX" id="CWh-wA-puP"/>
+                                                    <constraint firstItem="Gfc-WF-3FH" firstAttribute="leading" secondItem="LrX-PM-Rpx" secondAttribute="leading" id="JVS-Vi-hBD"/>
+                                                    <constraint firstItem="R5f-hd-cj8" firstAttribute="top" secondItem="Gfc-WF-3FH" secondAttribute="bottom" constant="8" id="YAm-yh-PIc"/>
+                                                    <constraint firstItem="LrX-PM-Rpx" firstAttribute="trailing" secondItem="Gfc-WF-3FH" secondAttribute="trailing" id="hzY-MS-a6f"/>
+                                                    <constraint firstItem="Gfc-WF-3FH" firstAttribute="top" secondItem="LrX-PM-Rpx" secondAttribute="top" constant="8" id="mPz-Ky-nNF"/>
+                                                </constraints>
+                                            </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7Zs-ZU-peS" userLabel="float_bg">
-                                                <rect key="frame" x="0.0" y="256" width="414" height="160"/>
+                                                <rect key="frame" x="0.0" y="384" width="414" height="160"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="FloatingLabelTextField without formatting" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TuV-4p-e7m">
                                                         <rect key="frame" x="0.0" y="8" width="414" height="20.5"/>
@@ -109,7 +135,7 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1tu-ce-tEo" userLabel="float_bg_w_formatting">
-                                                <rect key="frame" x="0.0" y="424" width="414" height="160"/>
+                                                <rect key="frame" x="0.0" y="552" width="414" height="160"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="FloatingLabelTextField with formatting" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UMk-pq-H9F">
                                                         <rect key="frame" x="0.0" y="8" width="414" height="20.5"/>
@@ -136,7 +162,7 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cUF-wv-BcO" userLabel="otp_bg">
-                                                <rect key="frame" x="0.0" y="592" width="414" height="120"/>
+                                                <rect key="frame" x="0.0" y="720" width="414" height="120"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OTPCodeTextField" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gwB-ev-g31">
                                                         <rect key="frame" x="0.0" y="8" width="414" height="20.5"/>
@@ -159,32 +185,6 @@
                                                     <constraint firstItem="97h-aD-3Z7" firstAttribute="centerX" secondItem="cUF-wv-BcO" secondAttribute="centerX" id="Smn-UX-JDw"/>
                                                     <constraint firstItem="gwB-ev-g31" firstAttribute="leading" secondItem="cUF-wv-BcO" secondAttribute="leading" id="auX-FB-ltr"/>
                                                     <constraint firstItem="gwB-ev-g31" firstAttribute="top" secondItem="cUF-wv-BcO" secondAttribute="top" constant="8" id="sqs-C6-EF5"/>
-                                                </constraints>
-                                            </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8XK-Ga-C4T" userLabel="phone_bg">
-                                                <rect key="frame" x="0.0" y="720" width="414" height="120"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PhoneTextField" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gfc-WF-3FH">
-                                                        <rect key="frame" x="0.0" y="8" width="414" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <color key="textColor" systemColor="systemGrayColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="R5f-hd-cj8" customClass="PhoneTextField" customModule="AGInputControls">
-                                                        <rect key="frame" x="191" y="36.5" width="32" height="34"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits"/>
-                                                    </textField>
-                                                </subviews>
-                                                <viewLayoutGuide key="safeArea" id="LrX-PM-Rpx"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="120" id="5R6-Bb-fNz"/>
-                                                    <constraint firstItem="R5f-hd-cj8" firstAttribute="centerX" secondItem="Gfc-WF-3FH" secondAttribute="centerX" id="CWh-wA-puP"/>
-                                                    <constraint firstItem="Gfc-WF-3FH" firstAttribute="leading" secondItem="LrX-PM-Rpx" secondAttribute="leading" id="JVS-Vi-hBD"/>
-                                                    <constraint firstItem="R5f-hd-cj8" firstAttribute="top" secondItem="Gfc-WF-3FH" secondAttribute="bottom" constant="8" id="YAm-yh-PIc"/>
-                                                    <constraint firstItem="LrX-PM-Rpx" firstAttribute="trailing" secondItem="Gfc-WF-3FH" secondAttribute="trailing" id="hzY-MS-a6f"/>
-                                                    <constraint firstItem="Gfc-WF-3FH" firstAttribute="top" secondItem="LrX-PM-Rpx" secondAttribute="top" constant="8" id="mPz-Ky-nNF"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bnf-N7-K9W" userLabel="otp_dashes">
@@ -242,12 +242,12 @@
                     </view>
                     <navigationItem key="navigationItem" id="23J-Lq-2ek"/>
                     <connections>
-                        <outlet property="field_1" destination="U12-cx-uta" id="I4c-E3-RXw"/>
-                        <outlet property="field_2" destination="97h-aD-3Z7" id="agT-bi-Bee"/>
                         <outlet property="fixedWidthPhoneField" destination="OZL-W4-6fL" id="tjU-81-2Ex"/>
                         <outlet property="floatTextField" destination="SAD-K4-JCd" id="FZg-Bc-19M"/>
                         <outlet property="floatingFieldNoFormatting" destination="EBj-8I-nur" id="RrO-QC-9Hf"/>
                         <outlet property="lettersField" destination="J9b-2i-JFx" id="Acx-8e-jiY"/>
+                        <outlet property="otpFieldWithAutoWidth" destination="97h-aD-3Z7" id="agT-bi-Bee"/>
+                        <outlet property="otpFieldWithConstrainedWidth" destination="U12-cx-uta" id="I4c-E3-RXw"/>
                         <outlet property="phoneField" destination="R5f-hd-cj8" id="oOV-4Y-gh6"/>
                     </connections>
                 </viewController>

--- a/Examples/Base.lproj/Main.storyboard
+++ b/Examples/Base.lproj/Main.storyboard
@@ -91,7 +91,10 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="R5f-hd-cj8" customClass="PhoneTextField" customModule="AGInputControls">
-                                                        <rect key="frame" x="191" y="36.5" width="32" height="34"/>
+                                                        <rect key="frame" x="8" y="36.5" width="398" height="64"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="64" id="27N-48-iZA"/>
+                                                        </constraints>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                     </textField>
@@ -102,8 +105,10 @@
                                                     <constraint firstAttribute="height" constant="120" id="5R6-Bb-fNz"/>
                                                     <constraint firstItem="R5f-hd-cj8" firstAttribute="centerX" secondItem="Gfc-WF-3FH" secondAttribute="centerX" id="CWh-wA-puP"/>
                                                     <constraint firstItem="Gfc-WF-3FH" firstAttribute="leading" secondItem="LrX-PM-Rpx" secondAttribute="leading" id="JVS-Vi-hBD"/>
+                                                    <constraint firstItem="LrX-PM-Rpx" firstAttribute="trailing" secondItem="R5f-hd-cj8" secondAttribute="trailing" constant="8" id="MEs-fu-m6a"/>
                                                     <constraint firstItem="R5f-hd-cj8" firstAttribute="top" secondItem="Gfc-WF-3FH" secondAttribute="bottom" constant="8" id="YAm-yh-PIc"/>
                                                     <constraint firstItem="LrX-PM-Rpx" firstAttribute="trailing" secondItem="Gfc-WF-3FH" secondAttribute="trailing" id="hzY-MS-a6f"/>
+                                                    <constraint firstItem="R5f-hd-cj8" firstAttribute="leading" secondItem="LrX-PM-Rpx" secondAttribute="leading" constant="8" id="mI8-9Y-F6I"/>
                                                     <constraint firstItem="Gfc-WF-3FH" firstAttribute="top" secondItem="LrX-PM-Rpx" secondAttribute="top" constant="8" id="mPz-Ky-nNF"/>
                                                 </constraints>
                                             </view>
@@ -242,13 +247,13 @@
                     </view>
                     <navigationItem key="navigationItem" id="23J-Lq-2ek"/>
                     <connections>
-                        <outlet property="fixedWidthPhoneField" destination="OZL-W4-6fL" id="tjU-81-2Ex"/>
+                        <outlet property="adaptiveWidthPhoneField" destination="OZL-W4-6fL" id="tjU-81-2Ex"/>
+                        <outlet property="fixedWidthPhoneField" destination="R5f-hd-cj8" id="oOV-4Y-gh6"/>
                         <outlet property="floatTextField" destination="SAD-K4-JCd" id="FZg-Bc-19M"/>
                         <outlet property="floatingFieldNoFormatting" destination="EBj-8I-nur" id="RrO-QC-9Hf"/>
                         <outlet property="lettersField" destination="J9b-2i-JFx" id="Acx-8e-jiY"/>
                         <outlet property="otpFieldWithAutoWidth" destination="97h-aD-3Z7" id="agT-bi-Bee"/>
                         <outlet property="otpFieldWithConstrainedWidth" destination="U12-cx-uta" id="I4c-E3-RXw"/>
-                        <outlet property="phoneField" destination="R5f-hd-cj8" id="oOV-4Y-gh6"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -287,16 +292,16 @@
             <color red="0.7839999794960022" green="0.81199997663497925" blue="0.91299998760223389" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="secondarySystemBackgroundColor">
-            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGrayColor">
-            <color red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGroupedBackgroundColor">
-            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Examples/Base.lproj/Main.storyboard
+++ b/Examples/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="AwU-e5-0VM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="AwU-e5-0VM">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -58,7 +58,7 @@
                                                 <subviews>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="OZL-W4-6fL" customClass="PhoneTextField" customModule="AGInputControls">
                                                         <rect key="frame" x="191" y="36.5" width="32" height="75.5"/>
-                                                        <color key="backgroundColor" name="BG"/>
+                                                        <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                     </textField>
@@ -286,14 +286,17 @@
         <namedColor name="BG">
             <color red="0.7839999794960022" green="0.81199997663497925" blue="0.91299998760223389" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="secondarySystemBackgroundColor">
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGrayColor">
-            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGroupedBackgroundColor">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Examples/Base.lproj/Main.storyboard
+++ b/Examples/Base.lproj/Main.storyboard
@@ -22,7 +22,7 @@
                                 <rect key="frame" x="0.0" y="92" width="414" height="770"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="XYD-44-ltN">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="968"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="988"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QQG-4o-0Dp" userLabel="letters">
                                                 <rect key="frame" x="0.0" y="0.0" width="414" height="120"/>
@@ -140,7 +140,7 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1tu-ce-tEo" userLabel="float_bg_w_formatting">
-                                                <rect key="frame" x="0.0" y="552" width="414" height="160"/>
+                                                <rect key="frame" x="0.0" y="552" width="414" height="180"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="FloatingLabelTextField with formatting" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UMk-pq-H9F">
                                                         <rect key="frame" x="0.0" y="8" width="414" height="20.5"/>
@@ -153,6 +153,11 @@
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                     </textField>
+                                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="sJG-EL-kl3" customClass="FormattingTextField" customModule="AGInputControls">
+                                                        <rect key="frame" x="8" y="96" width="32" height="34"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
                                                 </subviews>
                                                 <viewLayoutGuide key="safeArea" id="lV9-kH-fom"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -162,12 +167,14 @@
                                                     <constraint firstItem="UMk-pq-H9F" firstAttribute="leading" secondItem="lV9-kH-fom" secondAttribute="leading" id="VLj-2l-E1W"/>
                                                     <constraint firstItem="UMk-pq-H9F" firstAttribute="top" secondItem="lV9-kH-fom" secondAttribute="top" constant="8" id="adg-8m-k1H"/>
                                                     <constraint firstItem="SAD-K4-JCd" firstAttribute="leading" secondItem="UMk-pq-H9F" secondAttribute="leading" constant="8" id="cfO-pw-2mM"/>
-                                                    <constraint firstAttribute="height" constant="160" id="mJq-OB-c4O"/>
+                                                    <constraint firstAttribute="height" constant="180" id="mJq-OB-c4O"/>
+                                                    <constraint firstItem="sJG-EL-kl3" firstAttribute="leading" secondItem="SAD-K4-JCd" secondAttribute="leading" id="reo-iy-4x4"/>
+                                                    <constraint firstItem="sJG-EL-kl3" firstAttribute="top" secondItem="SAD-K4-JCd" secondAttribute="bottom" constant="19" id="tW8-b8-hSn"/>
                                                     <constraint firstItem="SAD-K4-JCd" firstAttribute="trailing" secondItem="UMk-pq-H9F" secondAttribute="trailing" constant="-8" id="wBo-A4-E6p"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cUF-wv-BcO" userLabel="otp_bg">
-                                                <rect key="frame" x="0.0" y="720" width="414" height="120"/>
+                                                <rect key="frame" x="0.0" y="740" width="414" height="120"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OTPCodeTextField" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gwB-ev-g31">
                                                         <rect key="frame" x="0.0" y="8" width="414" height="20.5"/>
@@ -193,7 +200,7 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bnf-N7-K9W" userLabel="otp_dashes">
-                                                <rect key="frame" x="0.0" y="848" width="414" height="120"/>
+                                                <rect key="frame" x="0.0" y="868" width="414" height="120"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OTPCodeTextField fixed dimentions" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y8i-YP-3kF">
                                                         <rect key="frame" x="0.0" y="8" width="414" height="20.5"/>
@@ -248,6 +255,7 @@
                     <navigationItem key="navigationItem" id="23J-Lq-2ek"/>
                     <connections>
                         <outlet property="adaptiveWidthPhoneField" destination="OZL-W4-6fL" id="tjU-81-2Ex"/>
+                        <outlet property="expirationDateField" destination="sJG-EL-kl3" id="A3b-Hf-kAQ"/>
                         <outlet property="fixedWidthPhoneField" destination="R5f-hd-cj8" id="oOV-4Y-gh6"/>
                         <outlet property="floatTextField" destination="SAD-K4-JCd" id="FZg-Bc-19M"/>
                         <outlet property="floatingFieldNoFormatting" destination="EBj-8I-nur" id="RrO-QC-9Hf"/>

--- a/Examples/Info.plist
+++ b/Examples/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.1.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Examples/SceneDelegate.swift
+++ b/Examples/SceneDelegate.swift
@@ -13,40 +13,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
     }
-
-    func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
-    }
-
-    func sceneDidBecomeActive(_ scene: UIScene) {
-        // Called when the scene has moved from an inactive state to an active state.
-        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
-    }
-
-    func sceneWillResignActive(_ scene: UIScene) {
-        // Called when the scene will move from an active state to an inactive state.
-        // This may occur due to temporary interruptions (ex. an incoming phone call).
-    }
-
-    func sceneWillEnterForeground(_ scene: UIScene) {
-        // Called as the scene transitions from the background to the foreground.
-        // Use this method to undo the changes made on entering the background.
-    }
-
-    func sceneDidEnterBackground(_ scene: UIScene) {
-        // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
-        // to restore the scene back to its current state.
-    }
-
-
 }
 

--- a/Examples/ViewController.swift
+++ b/Examples/ViewController.swift
@@ -14,9 +14,9 @@ class ViewController: UIViewController {
     let fixedLettersPrefixField = FormattingTextField()
     @IBOutlet weak var otpFieldWithConstrainedWidth: OTPCodeTextField!
     @IBOutlet weak var otpFieldWithAutoWidth: OTPCodeTextField!
-    @IBOutlet weak var phoneField: PhoneTextField!
-    @IBOutlet weak var floatTextField: FloatingLabelTextField!
+    @IBOutlet weak var adaptiveWidthPhoneField: PhoneTextField!
     @IBOutlet weak var fixedWidthPhoneField: PhoneTextField!
+    @IBOutlet weak var floatTextField: FloatingLabelTextField!
     @IBOutlet weak var floatingFieldNoFormatting: FloatingLabelTextField!
     
     
@@ -43,22 +43,24 @@ class ViewController: UIViewController {
             fixedLettersPrefixField.centerXAnchor.constraint(equalTo: lettersField.centerXAnchor)
         ])
         
-        fixedWidthPhoneField.font = UIFont(name: "Menlo", size: 30)
-        fixedWidthPhoneField.formattingMask = "+7 (###) ###-##-##"
-        fixedWidthPhoneField.exampleMask = "+7 (___) ___-__-__"
-        fixedWidthPhoneField.formattingDelegate = self
+        adaptiveWidthPhoneField.font = UIFont(name: "Menlo", size: 30)
+        adaptiveWidthPhoneField.formattingMask = "+7 (###) ###-##-##"
+        adaptiveWidthPhoneField.exampleMask = "+7 (___) ___-__-__"
+        adaptiveWidthPhoneField.formattingDelegate = self
         
-        fixedWidthPhoneField
+        adaptiveWidthPhoneField
             .publisher(for: \.text)
             .sink { text in
                 print("Value from publisher", text)
             }
             .store(in: &cancellables)
         
-        phoneField.font = .monospacedDigitSystemFont(ofSize: 30, weight: .light)
-        phoneField.formattingMask = "+7 ### ### ## ##"
-        phoneField.exampleMask = "+7 123 456 78 90"
-        phoneField.backgroundColor = UIColor.systemPink.withAlphaComponent(0.1)
+        fixedWidthPhoneField.font = .monospacedDigitSystemFont(ofSize: 30, weight: .light)
+        fixedWidthPhoneField.formattingMask = "+7 ### ### ## ##"
+        fixedWidthPhoneField.exampleMask = "+7 123 456 78 90"
+        fixedWidthPhoneField.backgroundColor = UIColor.systemPink.withAlphaComponent(0.1)
+        fixedWidthPhoneField.textAlignment = .center
+        fixedWidthPhoneField.clearButtonMode = .whileEditing
         
         floatingFieldNoFormatting.backgroundColor = UIColor.systemGreen.withAlphaComponent(0.15)
         floatingFieldNoFormatting.bottomText = "Test"
@@ -128,7 +130,7 @@ class ViewController: UIViewController {
         let ac = UIAlertController(title: "Actions", message: nil, preferredStyle: .actionSheet)
         
         ac.addAction(.init(title: "Paste phone", style: .default, handler: { [unowned self] _ in
-            fixedWidthPhoneField.text = "+79999999999"
+            adaptiveWidthPhoneField.text = "+79999999999"
         }))
         
         ac.addAction(.init(title: "Cancel", style: .cancel, handler: nil))

--- a/Examples/ViewController.swift
+++ b/Examples/ViewController.swift
@@ -44,25 +44,25 @@ class ViewController: UIViewController {
             fixedLettersPrefixField.centerXAnchor.constraint(equalTo: lettersField.centerXAnchor)
         ])
         
-        adaptiveWidthPhoneField.font = .systemFont(ofSize: 30)
+//        adaptiveWidthPhoneField.font = .systemFont(ofSize: 30)
         adaptiveWidthPhoneField.font = UIFont(name: "Courier", size: 24)
         adaptiveWidthPhoneField.formattingMask = "+7 (###) ###-##-##"
         adaptiveWidthPhoneField.exampleMask = "+7 (___) ___-__-__"
 //        adaptiveWidthPhoneField.exampleMask = "+7 (000) 000-00-00"
         adaptiveWidthPhoneField.formattingDelegate = self
         
-//        adaptiveWidthPhoneField
-//            .publisher(for: \.text)
-//            .sink { text in
-//                print("Value from publisher", text)
-//            }
-//            .store(in: &cancellables)
+        adaptiveWidthPhoneField
+            .publisher(for: \.text)
+            .sink { text in
+                print("Value from publisher", text)
+            }
+            .store(in: &cancellables)
         
-        fixedWidthPhoneField.font = .monospacedDigitSystemFont(ofSize: 30, weight: .light)
-        fixedWidthPhoneField.font = .systemFont(ofSize: 30)
+//        fixedWidthPhoneField.font = .monospacedDigitSystemFont(ofSize: 30, weight: .ultraLight)
+        fixedWidthPhoneField.font = .systemFont(ofSize: 30, weight: .ultraLight)
         fixedWidthPhoneField.formattingMask = "+7 (###) ###-##-##"
-        fixedWidthPhoneField.exampleMask = "+7 (___) ___-__-__"
-//        fixedWidthPhoneField.exampleMask = "+7 123 456 78 90"
+//        fixedWidthPhoneField.exampleMask = "+7 (___) ___-__-__"
+        fixedWidthPhoneField.exampleMask = "+7 (123) 456-78-90"
         fixedWidthPhoneField.backgroundColor = UIColor.systemPink.withAlphaComponent(0.1)
         fixedWidthPhoneField.textAlignment = .center
         fixedWidthPhoneField.clearButtonMode = .whileEditing
@@ -151,11 +151,11 @@ class ViewController: UIViewController {
 
 extension ViewController: FormattingTextFieldDelegate {
     func textField(textField: FormattingTextField, didProduce text: String?, isValid: Bool) {
-//        print(type(of: textField), text)
+        print(type(of: textField), text)
     }
     
     func textField(textField: FormattingTextField, didOccurUnacceptedCharacter char: Character) {
-//        print(type(of: textField), "did occur unaccepted char [\(char)]. Formatting mask:", textField.formattingMask)
+        print(type(of: textField), "did occur unaccepted char [\(char)]. Formatting mask:", textField.formattingMask)
     }
 }
 

--- a/Examples/ViewController.swift
+++ b/Examples/ViewController.swift
@@ -10,43 +10,58 @@ import AGInputControls
 import Combine
 
 class ViewController: UIViewController {
-    @IBOutlet weak var field_1: OTPCodeTextField!
-    @IBOutlet weak var field_2: OTPCodeTextField!
+    @IBOutlet weak var lettersField: FormattingTextField!
+    let fixedLettersPrefixField = FormattingTextField()
+    @IBOutlet weak var otpFieldWithConstrainedWidth: OTPCodeTextField!
+    @IBOutlet weak var otpFieldWithAutoWidth: OTPCodeTextField!
     @IBOutlet weak var phoneField: PhoneTextField!
     @IBOutlet weak var floatTextField: FloatingLabelTextField!
     @IBOutlet weak var fixedWidthPhoneField: PhoneTextField!
     @IBOutlet weak var floatingFieldNoFormatting: FloatingLabelTextField!
     
-    @IBOutlet weak var lettersField: FormattingTextField!
+    
     var cancellables = Set<AnyCancellable>()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        field_1.font = .monospacedDigitSystemFont(ofSize: 30, weight: .light)
-        field_1.decoration = .dash
-        field_1.showsCaret = true
-        field_1.decorationColor = .systemRed
+        lettersField.showsMaskIfEmpty = false
+        lettersField.formattingMask = "* ### ** ###"
+        lettersField.exampleMask = "A 123 BB 456"
+        lettersField.backgroundColor = UIColor.systemYellow.withAlphaComponent(0.25)
+        lettersField.font = UIFont(name: "Courier", size: 30)
+        lettersField.formattingDelegate = self
         
-        field_2.borderStyle = .none
-        field_2.backgroundColor = .white
-        field_2.font = .monospacedDigitSystemFont(ofSize: 30, weight: .light)
-        field_2.decorationColor = UIColor.systemBlue.withAlphaComponent(0.1)
-        field_2.decoration = .rect
-        field_2.letterSpacing = 24
-        field_2.length = 4
-        field_2.font = UIFont(name: "Avenir", size: 30)?.monospaced
-        field_1.showsCaret = false
+        fixedLettersPrefixField.formatter = DefaultFormatter(mask: "XYZ AB##")
+        fixedLettersPrefixField.exampleMask = "XYZ AB34"
+        fixedLettersPrefixField.font = .monospacedSystemFont(ofSize: 40, weight: .medium)
+        fixedLettersPrefixField.translatesAutoresizingMaskIntoConstraints = false
+        fixedLettersPrefixField.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.2)
+        lettersField.superview?.addSubview(fixedLettersPrefixField)
+        NSLayoutConstraint.activate([
+            fixedLettersPrefixField.topAnchor.constraint(equalTo: lettersField.bottomAnchor, constant: 8),
+            fixedLettersPrefixField.centerXAnchor.constraint(equalTo: lettersField.centerXAnchor)
+        ])
         
-        phoneField.backgroundColor = .systemBackground
+        fixedWidthPhoneField.font = UIFont(name: "Menlo", size: 30)
+        fixedWidthPhoneField.formattingMask = "+7 (###) ###-##-##"
+        fixedWidthPhoneField.exampleMask = "+7 (___) ___-__-__"
+        fixedWidthPhoneField.formattingDelegate = self
+        
+        fixedWidthPhoneField
+            .publisher(for: \.text)
+            .sink { text in
+                print("Value from publisher", text)
+            }
+            .store(in: &cancellables)
+        
         phoneField.font = .monospacedDigitSystemFont(ofSize: 30, weight: .light)
-        phoneField.formattingMask = "+# (###) ###-##-##"
-        phoneField.exampleMask = "+7 (888) 777-66-55"
+        phoneField.formattingMask = "+7 ### ### ## ##"
+        phoneField.exampleMask = "+7 123 456 78 90"
         phoneField.backgroundColor = UIColor.systemPink.withAlphaComponent(0.1)
         
         floatingFieldNoFormatting.backgroundColor = UIColor.systemGreen.withAlphaComponent(0.15)
         floatingFieldNoFormatting.bottomText = "Test"
-//        floatingFieldNoFormatting.textPadding = UIEdgeInsets(top: 20, left: 12, bottom: 20, right: 8)
         floatingFieldNoFormatting.showUnderlineView = true
         floatingFieldNoFormatting.highlightsWhenActive = true
         floatingFieldNoFormatting.clearButtonMode = .never
@@ -76,56 +91,23 @@ class ViewController: UIViewController {
         floatTextField.showUnderlineView = false
         floatTextField.borderWidth = 1
         floatTextField.placeholderColor = .systemGreen
-        
-        fixedWidthPhoneField.font = UIFont(name: "Menlo", size: 30)
-        
-//        fixedWidthPhoneField.exampleMask = "+7 900 432 89 67"
-//        fixedWidthPhoneField.formattingMask =  "+7 ### ### ## ##"
-        
-        fixedWidthPhoneField.formattingMask = "+7 (###) ###-##-##"
-        fixedWidthPhoneField.exampleMask = "+7 (___) ___-__-__"
-        
-//        fixedWidthPhoneField.exampleMask = "+31 (0) 20 76 06697"
-//        fixedWidthPhoneField.phoneMask =  "+31 (#) ## ## #####"
-        
-        fixedWidthPhoneField
-            .publisher(for: \.text)
-            .sink { text in
-                print("Value from publisher", text)
-            }.store(in: &cancellables)
-        
-        fixedWidthPhoneField.formattingDelegate = self
-        
-//        fixedWidthPhoneField
-//            .textPublisher()
-//            .sink { text in
-//                print("Value from publisher", text)
-//            }.store(in: &cancellables)
-        
-        field_1.addTarget(self, action: #selector(didChangeEditing), for: .editingChanged)
-        field_2.addTarget(self, action: #selector(didChangeEditing), for: .editingChanged)
-        phoneField.addTarget(self, action: #selector(didChangeEditing), for: .editingChanged)
-
         floatTextField.addTarget(self, action: #selector(didChangeEditing), for: .editingChanged)
-        fixedWidthPhoneField.addTarget(self, action: #selector(didChangeEditing), for: .editingChanged)
         
-        lettersField.showsMaskIfEmpty = false
-        lettersField.formattingMask = "* ### ** ###"
-        lettersField.exampleMask = "A 123 BB 456"
-        lettersField.backgroundColor = UIColor.systemYellow.withAlphaComponent(0.25)
-        lettersField.font = UIFont(name: "Courier", size: 30)
+        otpFieldWithAutoWidth.borderStyle = .none
+        otpFieldWithAutoWidth.backgroundColor = .secondarySystemBackground
+        otpFieldWithAutoWidth.font = .monospacedDigitSystemFont(ofSize: 30, weight: .light)
+        otpFieldWithAutoWidth.decorationColor = UIColor.systemBlue.withAlphaComponent(0.1)
+        otpFieldWithAutoWidth.decoration = .rect
+        otpFieldWithAutoWidth.letterSpacing = 24
+        otpFieldWithAutoWidth.length = 4
+        otpFieldWithAutoWidth.font = UIFont(name: "Avenir", size: 30)?.monospaced
+//        otpFieldWithAutoWidth.showsCaret = false
         
-        let testField = FormattingTextField()
-        testField.formatter = DefaultFormatter(mask: "XYZ AB##")
-        testField.exampleMask = "XYZ AB34"
-        testField.font = .monospacedSystemFont(ofSize: 40, weight: .medium)
-        testField.translatesAutoresizingMaskIntoConstraints = false
-        testField.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.2)
-        lettersField.superview?.addSubview(testField)
-        NSLayoutConstraint.activate([
-            testField.topAnchor.constraint(equalTo: lettersField.bottomAnchor, constant: 8),
-            testField.centerXAnchor.constraint(equalTo: lettersField.centerXAnchor)
-        ])
+        otpFieldWithConstrainedWidth.font = .monospacedDigitSystemFont(ofSize: 30, weight: .light)
+        otpFieldWithConstrainedWidth.decoration = .dash
+        otpFieldWithConstrainedWidth.showsCaret = true
+        otpFieldWithConstrainedWidth.decorationColor = .systemRed
+        otpFieldWithConstrainedWidth.backgroundColor = .secondarySystemBackground
         
         title = "AGInputControls Examples"
         navigationItem.rightBarButtonItem = UIBarButtonItem(image: .init(systemName: "ellipsis.circle"), style: .plain, target: self, action: #selector(moreActions))
@@ -156,12 +138,12 @@ class ViewController: UIViewController {
 }
 
 extension ViewController: FormattingTextFieldDelegate {
-    func textField(textField: AGInputControls.FormattingTextField, didProduce text: String?, isValid: Bool) {
-//        print("DELEGATE", text)
+    func textField(textField: FormattingTextField, didProduce text: String?, isValid: Bool) {
+        print(type(of: textField), text)
     }
     
-    func textField(textField: AGInputControls.FormattingTextField, didOccurUnacceptedCharacter char: Character) {
-        
+    func textField(textField: FormattingTextField, didOccurUnacceptedCharacter char: Character) {
+        print(type(of: textField), "did occur unaccepted char [\(char)]. Formatting mask:", textField.formattingMask)
     }
 }
 

--- a/Examples/ViewController.swift
+++ b/Examples/ViewController.swift
@@ -17,6 +17,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var adaptiveWidthPhoneField: PhoneTextField!
     @IBOutlet weak var fixedWidthPhoneField: PhoneTextField!
     @IBOutlet weak var floatTextField: FloatingLabelTextField!
+    @IBOutlet weak var expirationDateField: FormattingTextField!
     @IBOutlet weak var floatingFieldNoFormatting: FloatingLabelTextField!
     
     
@@ -43,21 +44,25 @@ class ViewController: UIViewController {
             fixedLettersPrefixField.centerXAnchor.constraint(equalTo: lettersField.centerXAnchor)
         ])
         
-        adaptiveWidthPhoneField.font = UIFont(name: "Menlo", size: 30)
+        adaptiveWidthPhoneField.font = .systemFont(ofSize: 30)
+        adaptiveWidthPhoneField.font = UIFont(name: "Courier", size: 24)
         adaptiveWidthPhoneField.formattingMask = "+7 (###) ###-##-##"
         adaptiveWidthPhoneField.exampleMask = "+7 (___) ___-__-__"
+//        adaptiveWidthPhoneField.exampleMask = "+7 (000) 000-00-00"
         adaptiveWidthPhoneField.formattingDelegate = self
         
-        adaptiveWidthPhoneField
-            .publisher(for: \.text)
-            .sink { text in
-                print("Value from publisher", text)
-            }
-            .store(in: &cancellables)
+//        adaptiveWidthPhoneField
+//            .publisher(for: \.text)
+//            .sink { text in
+//                print("Value from publisher", text)
+//            }
+//            .store(in: &cancellables)
         
         fixedWidthPhoneField.font = .monospacedDigitSystemFont(ofSize: 30, weight: .light)
-        fixedWidthPhoneField.formattingMask = "+7 ### ### ## ##"
-        fixedWidthPhoneField.exampleMask = "+7 123 456 78 90"
+        fixedWidthPhoneField.font = .systemFont(ofSize: 30)
+        fixedWidthPhoneField.formattingMask = "+7 (###) ###-##-##"
+        fixedWidthPhoneField.exampleMask = "+7 (___) ___-__-__"
+//        fixedWidthPhoneField.exampleMask = "+7 123 456 78 90"
         fixedWidthPhoneField.backgroundColor = UIColor.systemPink.withAlphaComponent(0.1)
         fixedWidthPhoneField.textAlignment = .center
         fixedWidthPhoneField.clearButtonMode = .whileEditing
@@ -94,6 +99,11 @@ class ViewController: UIViewController {
         floatTextField.borderWidth = 1
         floatTextField.placeholderColor = .systemGreen
         floatTextField.addTarget(self, action: #selector(didChangeEditing), for: .editingChanged)
+        
+        expirationDateField.formattingMask = "##/##"
+        expirationDateField.exampleMask = "03/24"
+        expirationDateField.backgroundColor = UIColor.systemGreen.withAlphaComponent(0.15)
+        expirationDateField.font = .systemFont(ofSize: 24, weight: .light)
         
         otpFieldWithAutoWidth.borderStyle = .none
         otpFieldWithAutoWidth.backgroundColor = .secondarySystemBackground
@@ -141,11 +151,11 @@ class ViewController: UIViewController {
 
 extension ViewController: FormattingTextFieldDelegate {
     func textField(textField: FormattingTextField, didProduce text: String?, isValid: Bool) {
-        print(type(of: textField), text)
+//        print(type(of: textField), text)
     }
     
     func textField(textField: FormattingTextField, didOccurUnacceptedCharacter char: Character) {
-        print(type(of: textField), "did occur unaccepted char [\(char)]. Formatting mask:", textField.formattingMask)
+//        print(type(of: textField), "did occur unaccepted char [\(char)]. Formatting mask:", textField.formattingMask)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This library contains 3 UITextField subclasses:
 ## Installation
 
 ### CocoaPods
-`pod AGInputControls`
+`pod 'AGInputControls'`
 
 ### Carthage
 `github "ivedeneev/AGInputControls"`


### PR DESCRIPTION
- Fix caret position when pasting text into `FormattingTextField`
- Add ability to use masks with underscores like `+31 _ __ __ __ __` for `PhoneTextField`
- Deprecate `setFormattedText` method
- Refactor examples; showcase Combine integration